### PR TITLE
compute fractional year in same time zone as model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -23,9 +23,8 @@ function Model(options){
 }
 
 Model.prototype.getTimedModel = function(date){
-	var year_int = date.getFullYear();
-	var year_start = new Date(year_int, 0, 1);
-	var fractional_year = (date.valueOf() - year_start.valueOf()) / (1000*3600*24*365);
+	var year_int = date.getUTCFullYear();
+	var fractional_year = (date.valueOf() - Date.UTC(year_int)) / (1000*3600*24*365);
 	var year = year_int + fractional_year;
 	var dyear = year - this.epoch;
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -30,15 +30,13 @@ function loadTestValues(){
 }
 
 function getModel(test){
-	var t0, t1;
+	var t1;
 	var year = test.date;
 	var year_int = Math.floor(year);
 	var year_fpart = year - year_int;
 	var dms = 1000*3600*24*365*year_fpart;
 
-	t0 = new Date(year_int, 0, 1);
-	t1 = new Date(t0.valueOf() + dms);
-
+	t1 = new Date(Date.UTC(year_int) + dms);
 	return geomagnetism.model(t1);
 }
 


### PR DESCRIPTION
The fractional year time computation in `model.js` was using local dates, the `valueOf` which can vary greatly with the user's - or server's - local timezone. UTC dates should be used because they coincide with the proper timezone in the model itself.

This was found by noticing a slight drift in values when running unit tests in CI (GMT) vs. our local dev timezone, despite sending a constant `new Date(1488386496470)` in the test itself.

That particular portion of this library is a little difficult to write a unit test for, or I would have added it. Also, this change should allow you to drastically increase the precision with which each value is tested.