### PR TITLE
Remove unused import of path

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1,5 +1,3 @@
-var path = require('path');
-
 var GeodeticCoord = require('./coords/geodetic.js');
 var Ellipsoid = require('./ellipsoid.js');
 var MagneticElements = require('./magnetic_elements.js');


### PR DESCRIPTION
`path` is a node builtin which causes problems for webpack 5 users. Plus it's not used in the code, so it can be deleted.